### PR TITLE
Add `--locked` option to cargo install commands in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     rustup toolchain install 1.42.0 && \
     rustup component add rustfmt clippy && \
-    cargo install cargo-compete && \
+    cargo install cargo-compete --locked && \
     cargo install cargo-snippet --features="binaries"
 
 COPY ./entrypoint.sh ./cargo_compete_new.sh ./create_gitkeep_in_testcases.sh ./cargo_snippet.sh /usr/local/bin/


### PR DESCRIPTION
This commit adds the --locked flag to the cargo install commands within the Dockerfile to ensure that dependencies are installed exactly as specified in Cargo.lock. This change enhances the reproducibility and stability of our builds by using fixed versions of dependencies.